### PR TITLE
fix: update draft when selecting datapoint via picker dialog

### DIFF
--- a/admin/custom/customComponents.js
+++ b/admin/custom/customComponents.js
@@ -720,6 +720,7 @@
                                             const selectedStr = Array.isArray(selected) ? selected[0] : selected;
                                             setShowSelectStateId(false);
                                             if (selectedStr) {
+                                                setDraftField('sourceState', selectedStr);
                                                 updateSelected('sourceState', selectedStr);
                                             }
                                         },

--- a/admin/custom/customComponentsDS.js
+++ b/admin/custom/customComponentsDS.js
@@ -1876,9 +1876,11 @@
                         setSelectContext(null);
                         if (!selectedStr) return;
                         if (selectContext.kind === 'itemSource') {
+                            setDraftField('sourceState', selectedStr);
                             updateSelected('sourceState', selectedStr);
                         }
                         if (selectContext.kind === 'input' && Number.isFinite(selectContext.index)) {
+                            setDraftInputField(selectContext.index, 'sourceState', selectedStr);
                             updateInput(selectContext.index, 'sourceState', selectedStr);
                         }
                         if (selectContext.kind === 'formulaFn') {


### PR DESCRIPTION
The state picker dialog (DialogSelectID) called updateSelected() to persist the chosen state to Admin, but did not update the local selectedDraft. Since editSensor/editItem prioritizes the draft over props, the old value was displayed until save/reload.

Now setDraftField/setDraftInputField is called before updateSelected so the UI reflects the selection immediately.

Affected: Sensor editor (customComponents.js) and Data-SOLECTRUS item editor (customComponentsDS.js).

https://claude.ai/code/session_01KouBLyfgLDVWk2kZdE7Uwc