### PR TITLE
fix: include unit in titleAffectingFields so list updates on unit change

### DIFF
--- a/admin/custom/customComponents.js
+++ b/admin/custom/customComponents.js
@@ -497,7 +497,7 @@
 
 			const updateSelected = (field, value) => {
 				// Only recalculate title for fields that affect it
-				const titleAffectingFields = ['enabled', 'SensorName'];
+				const titleAffectingFields = ['enabled', 'SensorName', 'unit'];
 				const shouldUpdateTitle = titleAffectingFields.includes(field);
 
 				const nextSensors = sensors.map((s, i) => {
@@ -512,7 +512,7 @@
 			// Batch multiple field updates into a single sensors update
 			// (avoids state overwrites when calling updateSelected() multiple times)
 			const updateSelectedMulti = updates => {
-				const titleAffectingFields = ['enabled', 'SensorName'];
+				const titleAffectingFields = ['enabled', 'SensorName', 'unit'];
 				var shouldUpdateTitle = false;
 				for (var k in updates) {
 					if (titleAffectingFields.indexOf(k) !== -1) {

--- a/admin/custom/customComponentsDS.js
+++ b/admin/custom/customComponentsDS.js
@@ -1643,7 +1643,7 @@
 
 			const updateSelected = (field, value) => {
 				// Only update title if field affects the title
-				const titleAffectingFields = ['enabled', 'name', 'group', 'targetId'];
+				const titleAffectingFields = ['enabled', 'name', 'group', 'targetId', 'unit'];
 				const shouldUpdateTitle = titleAffectingFields.includes(field);
 
 				const nextItems = items.map((it, i) => {


### PR DESCRIPTION
The _title was not recalculated when the unit field changed because 'unit' was missing from titleAffectingFields in both the sensor and DS item editors.

https://claude.ai/code/session_01KouBLyfgLDVWk2kZdE7Uwc