### PR TITLE
fix: display unit for DS items in tab.html Formula Engine dashboard

### DIFF
--- a/admin/tab.html
+++ b/admin/tab.html
@@ -858,7 +858,11 @@
                 valCls += ' na';
             }
             valEl.className = valCls;
-            valEl.textContent = valText;
+            if (hasVal && item.unit) {
+                valEl.textContent = valText + ' ' + item.unit;
+            } else {
+                valEl.textContent = valText;
+            }
             card.appendChild(valEl);
 
             /* state id + mode badge */


### PR DESCRIPTION
renderDs() was missing unit display — values were shown without unit while renderInflux() already appended sensor.unit. Now DS item values show the configured unit (e.g. "1234 W") when item.unit is set.

https://claude.ai/code/session_01KouBLyfgLDVWk2kZdE7Uwc