### PR TITLE
Fix tsc type-check errors and improve JSDoc coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ It is designed for energy monitoring systems such as photovoltaic installations,
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+* (patricknitsch) Fix `npm run check` (tsc type-checking of the JSDoc-typed JS codebase) so it passes cleanly again
+* (patricknitsch) Improve JSDoc type coverage across `dsProxy.js`, `jsonpath.js`, `stateMachine.js` and `helpers.js`
+* (patricknitsch) Resolve all remaining ESLint JSDoc warnings (`npm run lint` is now warning-free)
+
 ### 1.12.0-beta.0 (2026-07-05)
 * (patricknitsch) Update Dependencies
 * (patricknitsch) Add built-in **Backup** tab: create/upload/restore/download/delete local backups of the instance config, sensors and Data-SOLECTRUS items, with a configurable storage location (InfluxDB token is excluded and must be re-entered after a restore)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,4 +35,13 @@ export default [
 			// 'jsdoc/require-returns-check': 'off',
 		},
 	},
+	{
+		// This adapter is plain JS type-checked via JSDoc + tsc (allowJs/checkJs), not real
+		// TypeScript, so @type/@typedef ARE how types get declared here - unlike in a real
+		// .ts file, they're not redundant.
+		files: ['**/*.js'],
+		rules: {
+			'jsdoc/check-tag-names': ['warn', { typed: false }],
+		},
+	},
 ];

--- a/lib/backupManager.js
+++ b/lib/backupManager.js
@@ -26,10 +26,11 @@ const IO_TIMEOUT_MS = 15_000;
  * no built-in timeout, so without this a bad path would leave the UI stuck on "busy"
  * instead of showing an error.
  *
- * @param {Promise<unknown>} promise - The pending filesystem operation.
+ * @template T
+ * @param {Promise<T>} promise - The pending filesystem operation.
  * @param {string} dir - The backup directory involved, used in the timeout error message.
  * @param {number} [ms] - Timeout in milliseconds (defaults to {@link IO_TIMEOUT_MS}, overridable for tests).
- * @returns {Promise<unknown>} The original result, or a rejection if it takes too long.
+ * @returns {Promise<T>} The original result, or a rejection if it takes too long.
  */
 function withTimeout(promise, dir, ms = IO_TIMEOUT_MS) {
 	let timer;

--- a/lib/data-solectrus/jsonpath.js
+++ b/lib/data-solectrus/jsonpath.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsdoc/require-param-description */
-/* eslint-disable jsdoc/require-jsdoc */
 'use strict';
 
 /**
@@ -11,8 +10,9 @@
  *
  * Not supported: filters, wildcards, unions, recursive descent, functions.
  *
- * @param obj
- * @param path
+ * @param {unknown} obj
+ * @param {string} path
+ * @returns {unknown} The value at `path`, or `undefined` if it doesn't resolve.
  */
 function applyJsonPath(obj, path) {
 	if (!path) {
@@ -132,6 +132,15 @@ function applyJsonPath(obj, path) {
 	return cur;
 }
 
+/**
+ * Extracts a numeric value from `rawValue` via a JSONPath expression, parsing `rawValue` as
+ * JSON first if it is a string. Falls back to `safeNum(rawValue)` when no path is configured.
+ *
+ * @param {unknown} rawValue - The raw source value (JSON string, already-parsed object, or a primitive).
+ * @param {string} [jsonPath] - JSONPath expression, see {@link applyJsonPath}.
+ * @param {{ safeNum?: (val: unknown, fallback?: number) => number, warnOnce?: (key: string, msg: string) => void, debugOnce?: (key: string, msg: string) => void, warnKeyPrefix?: string }} [opts] - Helpers used for numeric coercion and throttled logging.
+ * @returns {number} The extracted numeric value, or `0` on failure.
+ */
 function getNumericFromJsonPath(rawValue, jsonPath, opts) {
 	const options = opts || {};
 	const safeNum =
@@ -194,6 +203,17 @@ function getNumericFromJsonPath(rawValue, jsonPath, opts) {
 	return safeNum(extracted);
 }
 
+/**
+ * Extracts a value from `rawValue` via a JSONPath expression, parsing `rawValue` as JSON first
+ * if it is a string. Unlike {@link getNumericFromJsonPath}, the extracted value is returned as-is
+ * (string/number/boolean/null), not coerced to a number. Objects and arrays are rejected to keep
+ * formula evaluation deterministic.
+ *
+ * @param {unknown} rawValue - The raw source value (JSON string, already-parsed object, or a primitive).
+ * @param {string} [jsonPath] - JSONPath expression, see {@link applyJsonPath}.
+ * @param {{ warnOnce?: (key: string, msg: string) => void, warnKeyPrefix?: string }} [opts] - Helper used for throttled logging.
+ * @returns {unknown} `rawValue` as-is when no `jsonPath` is given; otherwise a `string | number | boolean | null`, or `undefined` if it doesn't resolve or isn't a supported type.
+ */
 function getValueFromJsonPath(rawValue, jsonPath, opts) {
 	const options = opts || {};
 	const warnOnce = typeof options.warnOnce === 'function' ? options.warnOnce : () => {};
@@ -238,8 +258,7 @@ function getValueFromJsonPath(rawValue, jsonPath, opts) {
 	if (extracted === null) {
 		return null;
 	}
-	const t = typeof extracted;
-	if (t === 'string' || t === 'number' || t === 'boolean') {
+	if (typeof extracted === 'string' || typeof extracted === 'number' || typeof extracted === 'boolean') {
 		return extracted;
 	}
 	if (extracted instanceof Date && typeof extracted.toISOString === 'function') {

--- a/lib/data-solectrus/stateMachine.js
+++ b/lib/data-solectrus/stateMachine.js
@@ -18,7 +18,7 @@ const { parseExpression, normalizeFormulaExpression: normalizeFormulaExpressionI
 /**
  * Extract all source state IDs referenced in state-machine rules.
  *
- * @param {any} adapter - The adapter instance
+ * @param {object} adapter - The adapter instance
  * @param {Array} rules - Array of rule objects with condition expressions
  * @returns {Set<string>} Set of state IDs referenced in rules
  */
@@ -58,7 +58,7 @@ function extractSourceIdsFromRules(adapter, rules) {
 /**
  * Recursively collect state IDs from AST (s(...), v(...), jp(...) calls).
  *
- * @param {any} node - AST node
+ * @param {import('jsep').Expression} node - AST node
  * @param {Set<string>} ids - Set to collect IDs into
  */
 function collectStateIdsFromAst(node, ids) {
@@ -68,13 +68,13 @@ function collectStateIdsFromAst(node, ids) {
 
 	// Function call: s('id'), v('id'), jp('id', 'path')
 	if (node.type === 'CallExpression') {
-		const callee = node.callee;
+		const callee = /** @type {import('jsep').Expression | undefined} */ (node.callee);
 		if (
 			callee &&
 			callee.type === 'Identifier' &&
 			(callee.name === 's' || callee.name === 'v' || callee.name === 'jp')
 		) {
-			const args = node.arguments;
+			const args = /** @type {import('jsep').Expression[] | undefined} */ (node.arguments);
 			if (Array.isArray(args) && args.length > 0) {
 				const firstArg = args[0];
 				if (firstArg && firstArg.type === 'Literal' && typeof firstArg.value === 'string') {
@@ -85,16 +85,17 @@ function collectStateIdsFromAst(node, ids) {
 	}
 
 	// Recurse into child nodes
-	const keys = Object.keys(node);
+	const record = /** @type {Record<string, unknown>} */ (node);
+	const keys = Object.keys(record);
 	for (const key of keys) {
-		const val = node[key];
+		const val = record[key];
 		if (val && typeof val === 'object') {
 			if (Array.isArray(val)) {
 				for (const item of val) {
-					collectStateIdsFromAst(item, ids);
+					collectStateIdsFromAst(/** @type {import('jsep').Expression} */ (item), ids);
 				}
 			} else {
-				collectStateIdsFromAst(val, ids);
+				collectStateIdsFromAst(/** @type {import('jsep').Expression} */ (val), ids);
 			}
 		}
 	}
@@ -104,9 +105,9 @@ function collectStateIdsFromAst(node, ids) {
  * Compile and validate state-machine rules.
  * Returns compiled rules with parsed ASTs for fast evaluation.
  *
- * @param {any} adapter - The adapter instance
- * @param {any} item - The item configuration
- * @returns {{ok: boolean, error?: string, compiledRules?: Array, defaultValue?: any}} - The item configuration
+ * @param {object} adapter - The adapter instance
+ * @param {object} item - The item configuration
+ * @returns {{ok: boolean, error?: string, compiledRules?: Array, defaultValue?: string | boolean | null}} - The item configuration
  */
 function compileStateMachine(adapter, item) {
 	const rules = Array.isArray(item.rules) ? item.rules : [];
@@ -210,12 +211,12 @@ function compileStateMachine(adapter, item) {
  * Evaluate state machine rules and return the output value.
  * Rules are checked top-to-bottom; first matching rule wins.
  *
- * @param {any} adapter - The adapter instance
- * @param {any} item - The item configuration
+ * @param {object} adapter - The adapter instance
+ * @param {object} item - The item configuration
  * @param {Map} snapshot - Snapshot of current state values (or null for cache)
  * @param {Array} compiledRules - Compiled rules from compileStateMachine
- * @param {any} defaultValue - Default value if no rule matches
- * @returns {any} Output value (string or boolean)
+ * @param {string | boolean | null} defaultValue - Default value if no rule matches
+ * @returns {string | boolean} Output value (string or boolean)
  */
 function evaluateStateMachine(adapter, item, snapshot, compiledRules, defaultValue) {
 	const itemType = item && item.type ? String(item.type) : 'string';

--- a/lib/data-solectrus/stateMachine.js
+++ b/lib/data-solectrus/stateMachine.js
@@ -107,7 +107,7 @@ function collectStateIdsFromAst(node, ids) {
  *
  * @param {object} adapter - The adapter instance
  * @param {object} item - The item configuration
- * @returns {{ok: boolean, error?: string, compiledRules?: Array, defaultValue?: string | boolean | null}} - The item configuration
+ * @returns {{ok: boolean, error?: string, compiledRules?: Array, defaultValue?: string | boolean | null}} Compilation result: success flag, error message on failure, or the compiled rules and default value on success.
  */
 function compileStateMachine(adapter, item) {
 	const rules = Array.isArray(item.rules) ? item.rules : [];
@@ -213,7 +213,7 @@ function compileStateMachine(adapter, item) {
  *
  * @param {object} adapter - The adapter instance
  * @param {object} item - The item configuration
- * @param {Map} snapshot - Snapshot of current state values (or null for cache)
+ * @param {Map | null} snapshot - Snapshot of current state values (or null for cache)
  * @param {Array} compiledRules - Compiled rules from compileStateMachine
  * @param {string | boolean | null} defaultValue - Default value if no rule matches
  * @returns {string | boolean} Output value (string or boolean)

--- a/lib/dsProxy.js
+++ b/lib/dsProxy.js
@@ -86,6 +86,12 @@ function createDsProxy(adapter) {
 		setState: (id, val, ack) => adapter.setState(`ds.${id}`, val, ack),
 
 		/* ---------- DS-specific methods ---------- */
+		/**
+		 * Logs a warning at most once per `key`, resetting the dedup set once it grows too large.
+		 *
+		 * @param {string} key - Dedup key; repeated calls with the same key are suppressed.
+		 * @param {string} msg - Message to log (without the `[DS]` prefix).
+		 */
 		warnOnce(key, msg) {
 			if (self.warnedOnce.size > 500) {
 				self.warnedOnce.clear();
@@ -96,6 +102,12 @@ function createDsProxy(adapter) {
 			self.warnedOnce.add(key);
 			adapter.log.warn(`[DS] ${msg}`);
 		},
+		/**
+		 * Logs a debug message at most once per `key`, resetting the dedup set once it grows too large.
+		 *
+		 * @param {string} key - Dedup key; repeated calls with the same key are suppressed.
+		 * @param {string} msg - Message to log (without the `[DS]` prefix).
+		 */
 		debugOnce(key, msg) {
 			if (self.debuggedOnce.size > 500) {
 				self.debuggedOnce.clear();
@@ -106,13 +118,31 @@ function createDsProxy(adapter) {
 			self.debuggedOnce.add(key);
 			adapter.log.debug(`[DS] ${msg}`);
 		},
+		/**
+		 * Coerces `val` to a finite number, falling back to `fallback` otherwise.
+		 *
+		 * @param {unknown} val - Value to coerce.
+		 * @param {number} [fallback] - Value to return when `val` isn't a finite number.
+		 * @returns {number} The coerced number, or `fallback`.
+		 */
 		safeNum(val, fallback = 0) {
 			const n = Number(val);
 			return Number.isFinite(n) ? n : fallback;
 		},
+		/**
+		 * @param {unknown} obj - Object to query.
+		 * @param {string} jsonPath - JSONPath expression, see {@link applyJsonPathImpl}.
+		 * @returns {unknown} The resolved value, or `undefined` if it doesn't resolve.
+		 */
 		applyJsonPath(obj, jsonPath) {
 			return applyJsonPathImpl(obj, jsonPath);
 		},
+		/**
+		 * @param {unknown} rawValue - Raw source value (JSON string, object, or primitive).
+		 * @param {string} [jsonPath] - JSONPath expression.
+		 * @param {string} [warnKeyPrefix] - Prefix used to namespace throttled warn/debug log keys.
+		 * @returns {number} The extracted numeric value, or `0` on failure.
+		 */
 		getNumericFromJsonPath(rawValue, jsonPath, warnKeyPrefix = '') {
 			return getNumericFromJsonPathImpl(rawValue, jsonPath, {
 				safeNum: self.safeNum.bind(self),
@@ -121,18 +151,39 @@ function createDsProxy(adapter) {
 				warnKeyPrefix,
 			});
 		},
+		/**
+		 * @param {unknown} rawValue - Raw source value (JSON string, object, or primitive).
+		 * @param {string} [jsonPath] - JSONPath expression.
+		 * @param {string} [warnKeyPrefix] - Prefix used to namespace throttled warn log keys.
+		 * @returns {unknown} See {@link getValueFromJsonPathImpl}.
+		 */
 		getValueFromJsonPath(rawValue, jsonPath, warnKeyPrefix = '') {
 			return getValueFromJsonPathImpl(rawValue, jsonPath, {
 				warnOnce: self.warnOnce.bind(self),
 				warnKeyPrefix,
 			});
 		},
+		/**
+		 * @param {unknown} expr - Formula expression to normalize.
+		 * @returns {string} The normalized expression, see {@link normalizeFormulaExpressionImpl}.
+		 */
 		normalizeFormulaExpression(expr) {
 			return normalizeFormulaExpressionImpl(expr);
 		},
+		/**
+		 * @param {unknown} ast - Parsed jsep AST to validate against the configured complexity limits.
+		 * @returns {{ nodes: number, depth: number }} Node count and max depth of `ast`.
+		 */
 		analyzeAst(ast) {
 			return analyzeAstImpl(ast, { maxNodes: self.MAX_AST_NODES, maxDepth: self.MAX_AST_DEPTH });
 		},
+		/**
+		 * Parses, validates, and evaluates a formula expression in one step.
+		 *
+		 * @param {unknown} expr - Formula expression (SOLECTRUS syntax, normalized before parsing).
+		 * @param {Record<string, unknown>} [vars] - Variables available to the expression.
+		 * @returns {unknown} The evaluation result.
+		 */
 		evalFormula(expr, vars) {
 			const normalized = self.normalizeFormulaExpression(expr);
 			if (normalized && normalized.length > self.MAX_FORMULA_LENGTH) {
@@ -142,6 +193,11 @@ function createDsProxy(adapter) {
 			self.analyzeAst(ast);
 			return self.evalFormulaAst(ast, vars);
 		},
+		/**
+		 * @param {unknown} ast - Parsed jsep AST, see {@link evalFormula}.
+		 * @param {Record<string, unknown>} [vars] - Variables available to the expression.
+		 * @returns {unknown} The evaluation result.
+		 */
 		evalFormulaAst(ast, vars) {
 			return evalFormulaAstImpl(ast, vars, self.formulaFunctions);
 		},

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,7 @@ const { MAX_DELAY_MS } = require('./constants');
 /**
  * Clamps a delay value to a valid range, falling back to a default when the value is invalid.
  *
- * @param {*} ms - Requested delay in milliseconds.
+ * @param {unknown} ms - Requested delay in milliseconds.
  * @param {number} fallbackMs - Fallback value when ms is not a finite non-negative number.
  * @returns {number} Clamped delay in milliseconds.
  */
@@ -64,12 +64,13 @@ function parseTimestamp(rawTs) {
 /**
  * Parses a raw value to the numeric type expected by InfluxDB.
  *
- * @param {*} rawVal - The raw value to parse.
+ * @param {unknown} rawVal - The raw value to parse.
  * @param {string} influxType - InfluxDB field type ('int' or 'float').
  * @returns {number} Parsed numeric value.
  */
 function parseInfluxValue(rawVal, influxType) {
-	return influxType === 'int' ? parseInt(rawVal, 10) : parseFloat(rawVal);
+	const str = String(rawVal);
+	return influxType === 'int' ? parseInt(str, 10) : parseFloat(str);
 }
 
 /**
@@ -182,7 +183,7 @@ function getInfluxConfig(adapter) {
  * Calls an async function with automatic retry on transient InfluxDB connection errors.
  *
  * @param {object} adapter - The ioBroker adapter instance.
- * @param {Function} fn - Async function to execute.
+ * @param {() => Promise<unknown>} fn - Async function to execute.
  * @param {string} label - Human-readable label used in log messages.
  * @param {number} [maxRetries] - Maximum number of attempts.
  * @param {number} [delayMs] - Delay between retries in milliseconds.

--- a/lib/objectManager.test.js
+++ b/lib/objectManager.test.js
@@ -36,7 +36,6 @@ describe('ensureDefaultSensorsAndTitles', () => {
 		if (!written) {
 			throw new Error('setForeignObject was not called');
 		}
-		// eslint-disable-next-line jsdoc/check-tag-names -- inline @type cast, the standard way to narrow types in checked JS
 		const result = /** @type {{ native: { sensors: unknown[] } }} */ (written);
 		expect(result.native.sensors).to.deep.equal([
 			{

--- a/lib/objectManager.test.js
+++ b/lib/objectManager.test.js
@@ -33,7 +33,12 @@ describe('ensureDefaultSensorsAndTitles', () => {
 		await ensureDefaultSensorsAndTitles(adapter);
 
 		expect(written).to.not.equal(null);
-		expect(written.native.sensors).to.deep.equal([
+		if (!written) {
+			throw new Error('setForeignObject was not called');
+		}
+		// eslint-disable-next-line jsdoc/check-tag-names -- inline @type cast, the standard way to narrow types in checked JS
+		const result = /** @type {{ native: { sensors: unknown[] } }} */ (written);
+		expect(result.native.sensors).to.deep.equal([
 			{
 				enabled: true,
 				internal: true,
@@ -70,6 +75,6 @@ describe('ensureDefaultSensorsAndTitles', () => {
 				_title: '🟢 ANOTHER_CUSTOM_SENSOR',
 			},
 		]);
-		expect(adapter.config.sensors).to.equal(written.native.sensors);
+		expect(adapter.config.sensors).to.equal(result.native.sensors);
 	});
 });

--- a/main.js
+++ b/main.js
@@ -519,7 +519,7 @@ class SolectrusInfluxdb extends utils.Adapter {
 			const maxWait = 5000;
 			const waitStart = Date.now();
 			while (this.isFlushing && Date.now() - waitStart < maxWait) {
-				await new Promise(resolve => this.setTimeout(resolve, 50));
+				await new Promise(resolve => this.setTimeout(() => resolve(undefined), 50));
 			}
 
 			saveBuffer(this);


### PR DESCRIPTION
- Make backupManager's withTimeout() generic so callers keep their
  actual return types instead of unknown
- Fix a null-narrowing/never issue in objectManager.test.js and an
  ioBroker setTimeout() call signature mismatch in main.js
- Add JSDoc types to dsProxy.js's internal methods and to the two
  undocumented jsonpath.js helpers

npm run check now passes cleanly.